### PR TITLE
allow analyze method to accept a URL as a string,  check if valid URI

### DIFF
--- a/lib/yahoo_content_analysis/client.rb
+++ b/lib/yahoo_content_analysis/client.rb
@@ -45,7 +45,7 @@ module YahooContentAnalysis
     end
 
     def condition(content)
-      content.is_a?(URI) ? url(content) : text(content)
+      uri?(content) ? url(content) : text(content)
     end
 
     def url(content)
@@ -64,6 +64,15 @@ module YahooContentAnalysis
         'related_entities' => 'true',
         'show_metadata'    => 'true'
       }
+    end
+
+    def uri?(string)
+      uri = URI.parse(string)
+      %w( http https ).include?(uri.scheme)
+    rescue URI::BadURIError
+      false
+    rescue URI::InvalidURIError
+      false
     end
 
   end


### PR DESCRIPTION
proposed resolution for https://github.com/PRX/yahoo_content_analysis/issues/3

this supports

```
 YahooContentAnalysis::Client.new.analyze('http://www.cnn.com/2011/11/11/world/europe/greece-main/index.html')
```

and

```
 YahooContentAnalysis::Client.new.analyze(URI('http://www.cnn.com/2011/11/11/world/europe/greece-main/index.html'))
```
